### PR TITLE
Add video trailer to hero

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -12,6 +12,17 @@ import Navigation from "./Navigation.astro";
   <Navigation />
   <div class="relative h-[700px] overflow-hidden">
     <div
+      class="absolute left-[200px] top-[100px] rounded-xl overflow-hidden shadow-lg"
+    >
+      <iframe
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/4nUWiebkEOw"
+        title="The Book of Aaru Trailer"
+        allowfullscreen
+      ></iframe>
+    </div>
+    <div
       class="absolute right-[200px] top-[100px] flex flex-col gap-4 justify-center items-center max-w-[550px] bg-black/50 backdrop-blur-sm p-10 rounded-xl shadow-lg"
     >
       <h1


### PR DESCRIPTION
## Summary
- embed YouTube trailer in the hero banner

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684098ae05b08321b3dea41e2e5e5c60